### PR TITLE
fix: update URLS to download Prithvi Segmentation Model weights and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 #   blacken-docs: Checks docs follow black format standard.
 #   pydocstyle: Checking docstring style.
 
-default_stages: ["commit", "commit-msg", "push"]
+default_stages: ["pre-commit", "commit-msg", "pre-push"]
 default_language_version:
   python: python3.10
 

--- a/instageo/model/model.py
+++ b/instageo/model/model.py
@@ -137,14 +137,14 @@ class PrithviSeg(nn.Module):
         super().__init__()
         weights_dir = Path.home() / ".instageo" / "prithvi"
         weights_dir.mkdir(parents=True, exist_ok=True)
-        weights_path = weights_dir / "Prithvi_100M.pt"
-        cfg_path = weights_dir / "Prithvi_100M_config.yaml"
+        weights_path = weights_dir / "Prithvi_EO_V1_100M.pt"
+        cfg_path = weights_dir / "config.yaml"
         download_file(
-            "https://huggingface.co/ibm-nasa-geospatial/Prithvi-100M/resolve/main/Prithvi_100M.pt?download=true",  # noqa
+            "https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-1.0-100M/resolve/main/Prithvi_EO_V1_100M.pt?download=true",  # noqa
             weights_path,
         )
         download_file(
-            "https://huggingface.co/ibm-nasa-geospatial/Prithvi-100M/raw/main/Prithvi_100M_config.yaml",  # noqa
+            "https://huggingface.co/ibm-nasa-geospatial/Prithvi-100M/raw/main/config.yaml",  # noqa
             cfg_path,
         )
         checkpoint = torch.load(weights_path, map_location="cpu")

--- a/instageo/model/model.py
+++ b/instageo/model/model.py
@@ -160,7 +160,6 @@ class PrithviSeg(nn.Module):
         if freeze_backbone:
             for param in model.parameters():
                 param.requires_grad = False
-        del checkpoint["pos_embed"]
         _ = model.load_state_dict(checkpoint, strict=False)
 
         self.prithvi_100M_backbone = model


### PR DESCRIPTION
The [name of the config](https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-1.0-100M/commit/c2ee813e7148af8d3d6b8d234b8ebd9c1039af58) and the weights of the [Prithvi](https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-1.0-100M) model on Huggingface have changed. 

This PR updates the URLs. The commit history also shows that the [weights have changed to a new format ](https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-1.0-100M/commit/4d894e1487bab8bde27cb2f44b9b7c4b1535685e) and the [inference code has been updated](https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-1.0-100M/commit/7bfe9ea2ca8dbd06046991bd9157dd2e44eb7a70). I haven't tested yet how this impacts the InstaGeo code.  